### PR TITLE
Added more issues button

### DIFF
--- a/getstarted/index.html
+++ b/getstarted/index.html
@@ -11,7 +11,26 @@ title: New to OpenSMC?
         <li class="list-group-item">Start a discussion about <a href="https://github.com/opensmc/project-ideas/issues">a new project idea</a>. It's good to talk about it first to see if anything similar has been built already.</li>
         <li class="list-group-item">Help us research the quality of San Mateo Conuty's Open Data on the national <a href="http://us-city.census.okfn.org/">open data census</a>.</li>
         <li class="list-group-item">Help us give some User Experience advice for important online city services for San Mateo County at <a href="http://citizenonboard.com/">http://citizenonboard.com/</a>. We have connections to the County departments that can use your advice to improve these services.</li>
-        <li class="list-group-item">Code for San Mateo County anytime by helping us with our open GitHub Issues: <iframe id="widget" src="http://codeforamerica.org/geeks/civicissues/widget?organization_name=OpenSMC&number=3" width="100%" height="500" frameBorder="0"></iframe> </li>
+        <li class="list-group-item" style="text-align: center">Code for San Mateo County anytime by helping us with our open GitHub Issues:
+					<iframe
+						id="widget"
+						src="http://codeforamerica.org/geeks/civicissues/widget?organization_name=OpenSMC&number=6"
+						width="100%"
+						height="500"
+						frameBorder="0">
+					</iframe>
+					<a
+						role="button"
+						class="btn btn-primary"
+						style="
+							color:white;
+							font-size:18px;
+							font-family: 'Quattrocento', 'Georgia',serif;
+							"
+						href="http://www.codeforamerica.org/geeks/civicissues/widget?organization_name=OpenSMC">
+						More Issues
+					</a>
+				</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Added the more issues button to the get started page.  
1. Related to issue: https://github.com/opensmc/opensmc.github.io/issues/2
2. Formatted html to make it more readable while developing (let me know if you want me to revert this portion! Would be more than happy to do so. it's probably why the diff looks so weird.)
3. Button links to http://www.codeforamerica.org/geeks/civicissues/widget?organization_name=OpenSMC
