### PR TITLE
Fix for broken codeforamerica-api. Hopefully temporary :(

### DIFF
--- a/js/projects.js
+++ b/js/projects.js
@@ -6,7 +6,7 @@ function slugify(text) {
   return text;
 }
 
-var cfapi_url = 'http://codeforamerica.org/api/organizations/OpenSMC/projects';
+var cfapi_url = 'https://codeforamerica-api.herokuapp.com/api/organizations/OpenSMC/projects';
 
 // Go get projects! Then show them off.
 $.getJSON(cfapi_url, showProjects);


### PR DESCRIPTION
All the routing for Code for America's websites is broke. I don't even know how or who or when it may be fixed, if it will. In the meantime, here is a PR to get your website working again. The Heroku version should always be dependable. Sorry if our mishaps took up some of your volunteer time
